### PR TITLE
Add new models to the list.

### DIFF
--- a/hardware/laptops/en.md
+++ b/hardware/laptops/en.md
@@ -33,9 +33,11 @@ fact compatible.
 
 ### Asus
 
+- Asus EEE-PC 1001PX
 - Asus EEE-PC 1011PX
 - Asus G750JZA
 - Asus K53U
+- Asus K55VM
 - Asus M50VM
 - Asus N501JW
 - Asus N61JA


### PR DESCRIPTION
Add two new models to the list. I own both and work flawessly out of the box:
- Asus EEE-PC 1001PX
- Asus K55VM

Note: the K55VM works with opensource drivers. Nvidia propetary Optimus support is not there yet...