### PR TITLE
Virtualbox: now requires isl-devel

### DIFF
--- a/software/virtualbox/en.md
+++ b/software/virtualbox/en.md
@@ -11,7 +11,7 @@ Make sure you have the necessary packages installed:
 
 ``` bash
 sudo eopkg upgrade
-sudo eopkg install gcc make autoconf binutils kernel-headers xorg-server-devel
+sudo eopkg install gcc make autoconf binutils isl-devel kernel-headers xorg-server-devel
 ```
 
 Reboot your system first so that it's all up to date.


### PR DESCRIPTION
I believe this is one of the changes from here (I learnt it from him anyway) https://dev.solus-project.com/T2782 but it is cropping up more and more often, so thought I'd get it added sooner rather than later. 
It's needed now gcc is built with it. 