### PR TITLE
Add missing [Packager] in Building a Package page

### DIFF
--- a/packaging/building-a-package/en.md
+++ b/packaging/building-a-package/en.md
@@ -13,6 +13,7 @@ This file lives in the `.solus` folder of your home directory. You will need to 
 file so that the packager details are stored within the resulting binary package.
 
 ``` ini
+[Packager]
 Name=Your Name Here
 Email=your.email@address
 ```


### PR DESCRIPTION
This was missing from the migration from wiki to new help-center-docs.

@JoshStrobl also commented this during the packaging video from last week :)