### PR TITLE
System restart needed to build local packages

### DIFF
--- a/packaging/building-a-package/en.md
+++ b/packaging/building-a-package/en.md
@@ -67,9 +67,11 @@ Your folder should look something similar to this:
 | Makefile.iso
 ```
 
+You should now restart your system prior to building any packages.
+
 ## Building packages (Solus only)
 
-After setting up common, you can now build the package. Note that build dependencies and such will be installed locally (in the chroot environment).
+After setting up common and restarting your system, you can now build the package. Note that build dependencies and such will be installed locally (in the chroot environment).
 
 ``` bash
 make


### PR DESCRIPTION
This tripped me up while following the packaging docs, which are awesome btw.

Per a conversation with @JoshStrobl on IRC, in order to be able to make local
packages, a restart of the system is necessary after installing
`solbuild` and `common`. After that, it worked as expected. Hoping this saves others some time.