### PR TITLE
Make libglu a requirement for HoN

### DIFF
--- a/gaming/heroes-of-newerth/en.md
+++ b/gaming/heroes-of-newerth/en.md
@@ -8,7 +8,7 @@ First, install the latest version of HoN by downloading it and running "HoNClien
 Assuming that you install to ~/HoN (default), you only need to run two commands:
 
 ``` bash
-sudo eopkg it gconf libgcrypt11
+sudo eopkg it gconf libgcrypt11 libglu
 ```
 
 That installs all of the dependencies that HoN needs.


### PR DESCRIPTION
As per a user on IRC, they followed the instructions but were still missing libglu. With the multiple ISOs, it's much more likely that this will now be missing on the system, so adding it back in.