### PR TITLE
update CONFOPTS source link in package.yml doc

### DIFF
--- a/packaging/package.yml/en.md
+++ b/packaging/package.yml/en.md
@@ -154,7 +154,7 @@ Macro | Description
 Macro | Description
 ---- | ----
 **%ARCH%** | Indicates the current build architecture.
-**%CONFOPTS%** | Flags / options for configuration, such as `--prefix=/usr`. [Full List.](https://github.com/solus-project/ypkg/blob/master/ypkg2/rc.yml#L117)
+**%CONFOPTS%** | Flags / options for configuration, such as `--prefix=/usr`. [Full List.](https://github.com/solus-project/ypkg/blob/master/ypkg2/rc.yml#L127-L130)
 **%CFLAGS%** | cflags as set in `eopkg.conf`
 **%CXXFLAGS%** | cxxflags as set in `eopkg.conf`
 **%LDFLAGS%** | ldflags as set in `eopkg.conf`


### PR DESCRIPTION
I noticed the Full List link in the package.yml doc wasn't lining up with the right location in `rc.yml` anymore. Update to reflect current position in that file.