### PR TITLE
added Asus K401UQK to Laptop-Compatibility list

### DIFF
--- a/hardware/laptops/en.md
+++ b/hardware/laptops/en.md
@@ -27,7 +27,7 @@ This list should not suggest that *only* such devices listed below are compatibl
 ### Alienware
 
 - Alienware 14
-- Alienware 17 R3
+solus- Alienware 17 R3
 
 ### Apple
 
@@ -39,6 +39,7 @@ This list should not suggest that *only* such devices listed below are compatibl
 - Asus EEE-PC 1001PX
 - Asus EEE-PC 1011PX
 - Asus G750JZA
+- Asus K401UQK
 - Asus K53U
 - Asus K55VM
 - Asus M50VM

--- a/hardware/laptops/en.md
+++ b/hardware/laptops/en.md
@@ -27,7 +27,7 @@ This list should not suggest that *only* such devices listed below are compatibl
 ### Alienware
 
 - Alienware 14
-solus- Alienware 17 R3
+- Alienware 17 R3
 
 ### Apple
 


### PR DESCRIPTION
A laptop from 2016 with an Intel Core i5 (Kabylake ULV) processor and two gpu's ( Intel HD620 and Nvidia GT940MX ), battery lasts for about 3 - 5 hours* (Full Power) and 6+ Hours* (Light Use). Runs Solus 3 x64 with all latest updates, no problems so far.

*NOTE: dGPU disabled.