### PR TITLE
Issue #22 Add verification section to Installation ISO (Linux and Mac) 

### DIFF
--- a/installation/preparing-to-install/en.md
+++ b/installation/preparing-to-install/en.md
@@ -10,6 +10,28 @@ The first step to installing Solus is acquiring the correct media. The Solus Pro
 
 You can download a Solus ISO by going to our [Download page](/download).
 
+## Verifying the ISO
+
+### Linux and Mac
+Download the relevant Solus ISO SHA256SUMS: File, Signed File and Public Key from the [Download page](/download).
+
+**Note:** it is advisable that the files are all placed in the same folder.
+
+#### Import the public key
+```bash
+gpg --import <Public Key>.gpg
+```
+
+#### Verify SHA256SUMS file signature
+```bash
+gpg --verify <Signed File>.sign <File>.sha256sum
+```
+
+#### Verify ISO
+```bash
+sha256sum -c Solus-3-Budgie.sha256sum | grep OK
+```
+
 ---
 
 ## Getting the Right Tool


### PR DESCRIPTION
I've added some instructions to validate the ISO to the "preparing-to-install" page. The instructions are for Linux and Mac users, I need to do some research for Windows, I am guessing stuff needs to be downloaded for that. 

It would be good if there was a way to validate the public key fingerprint to make sure that even the key is valid before checking the checksum signature and then the ISO but I am not sure how to achieve this, I am assuming the public key fingerprint needs to be securely available somewhere for people to reference?
