### PR TITLE
Changed Zsh link

### DIFF
--- a/configuration/changing-shell/en.md
+++ b/configuration/changing-shell/en.md
@@ -10,7 +10,7 @@ Solus makes available other shells via our repository, with a full list availabl
 
 - Dash
 - [Fish](https://fishshell.com/)
-- [Zsh](http://zsh.sourceforge.net/)
+- [Zsh](http://www.zsh.org/)
 
 ## Installation
 

--- a/configuration/changing-shell/en.md
+++ b/configuration/changing-shell/en.md
@@ -10,7 +10,7 @@ Solus makes available other shells via our repository, with a full list availabl
 
 - Dash
 - [Fish](https://fishshell.com/)
-- [Zsh](http://www.zsh.org/)
+- [Zsh](https://www.zsh.org/)
 
 ## Installation
 

--- a/configuration/changing-shell/en.md
+++ b/configuration/changing-shell/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Changing Shell"
-lastmod = "2017-05-25T18:19:11+03:00"
+lastmod = "2017-12-30T18:25:00+03:00"
 +++
 # Changing Shell
 

--- a/hardware/laptops/en.md
+++ b/hardware/laptops/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Laptop Compatibility"
-lastmod = "2017-11-02T03:28:55+02:00"
+lastmod = "2017-12-28T21:23:00+03:00"
 +++
 # Laptop Compatibility
 

--- a/hardware/laptops/en.md
+++ b/hardware/laptops/en.md
@@ -136,6 +136,7 @@ This list should not suggest that *only* such devices listed below are compatibl
 - Lenovo ThinkPad T430
 - Lenovo ThinkPad T440
 - Lenovo ThinkPad T440s
+- Lenovo ThinkPad T470
 - Lenovo ThinkPad T560
 - Lenovo ThinkPad T570
 - Lenovo ThinkPad W520 4270CTO

--- a/hardware/wireless-chipsets/en.md
+++ b/hardware/wireless-chipsets/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Wireless Chipsets Compatibility"
-lastmod = "2017-04-13T17:39:14+03:00"
+lastmod = "2017-12-28T22:22:00+03:00"
 +++
 # Wireless Chipsets Compatibility
 

--- a/hardware/wireless-chipsets/en.md
+++ b/hardware/wireless-chipsets/en.md
@@ -39,6 +39,7 @@ This list should not suggest that *only*- such devices listed below are compatib
 - Intel Centrino Advanced-N 6235
 - Intel Centrino Ultimate-N 6300
 - Intel Centrino Wireless-N 2230
+- Intel Corporation Wireless 8265 / 8275 [8086:24fd] (rev 78)
 - Intel PRO/Wireless 3945ABG
 - Intel PRO/Wireless 4965 AG or AGN
 - Intel Ultimate N WiFi Link 5300

--- a/hardware/wireless-chipsets/en.md
+++ b/hardware/wireless-chipsets/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Wireless Chipsets Compatibility"
-lastmod = "2017-12-28T22:22:00+03:00"
+lastmod = "2017-12-28T21:24:00+03:00"
 +++
 # Wireless Chipsets Compatibility
 


### PR DESCRIPTION
Changed the Zsh link to https://www.zsh.org/, according to [Wikipedia](https://en.wikipedia.org/wiki/Z_shell)