### PR TITLE
Add info on enabling PHP with httpd

### DIFF
--- a/software/httpd/en.md
+++ b/software/httpd/en.md
@@ -26,6 +26,29 @@ Therefore, to make modifications to httpd's configuration, you must first create
 
 By default, httpd's DocumentRoot is set to `/var/www/`, thus files you desire to be accessible via your httpd server must be copied to that location.
 
+### PHP Support
+
+To get PHP working, install it from the Software Center or via terminal:
+
+``` bash
+sudo eopkg install php
+```
+
+Because PHP is loaded via FPM and FastCGI and not via an Apache module, to enable PHP you must create a new file, `/etc/httpd/conf.d/php.conf`, with the following lines:
+
+```
+LoadModule proxy_module lib64/httpd/mod_proxy.so
+LoadModule proxy_fcgi_module lib64/httpd/mod_proxy_fcgi.so
+<FilesMatch \.php$>
+SetHandler "proxy:fcgi://127.0.0.1:9000"
+</FilesMatch>
+<IfModule dir_module>
+DirectoryIndex index.php index.html
+</IfModule>
+```
+
+[More info here](https://solus-project.com/forums/viewtopic.php?f=11&t=7440&p=21756#p21756).
+
 ### Management
 
 Managing httpd is done via systemd, using the following commands:

--- a/software/httpd/en.md
+++ b/software/httpd/en.md
@@ -1,6 +1,6 @@
 +++
 title = "httpd (Apache)"
-lastmod = "2017-04-23T18:37:45+03:00"
+lastmod = "2018-01-19T16:14:40+03:00"
 +++
 # httpd (Apache)
 
@@ -47,7 +47,11 @@ DirectoryIndex index.php index.html
 </IfModule>
 ```
 
-[More info here](https://solus-project.com/forums/viewtopic.php?f=11&t=7440&p=21756#p21756).
+Now, to load the changes, run:
+
+```bash
+sudo systemctl restart httpd && sudo systemctl restart php-fpm
+```
 
 ### Management
 


### PR DESCRIPTION
This is taken from [der_eismann's post on the forums](https://solus-project.com/forums/viewtopic.php?f=11&t=7440&p=21756#p21756).

To me, it's valuable to put this in the same place. I was trying to set up a LAMP stack and the help page was the first thing I found. However, it took a while until I found the forum page that described how to get PHP to work.