### PR TITLE
Added /run mount for Boot Rescue.

### DIFF
--- a/troubleshooting/boot-rescue/en.md
+++ b/troubleshooting/boot-rescue/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Boot Rescue"
-lastmod = "2017-09-22T20:08:14+03:00"
+lastmod = "2018-04-27T19:59:49+00:00"
 aliases = ["/articles/configuration/modifying-grub/en/", "/articles/repair-and-recovery/boot-rescue/en/"]
 +++
 # Boot Rescue


### PR DESCRIPTION
# Description

Added /run mount for Boot Rescue so people can do DNS resolution for installing stuff or what have you. Whitespace change was not intended, browser did that I believe. 
