### PR TITLE
Change to using https where possible

### DIFF
--- a/configuration/changing-shell/en.md
+++ b/configuration/changing-shell/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Changing Shell"
-lastmod = "2017-05-25T18:19:11+03:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # Changing Shell
 
@@ -10,7 +10,7 @@ Solus makes available other shells via our repository, with a full list availabl
 
 - Dash
 - [Fish](https://fishshell.com/)
-- [Zsh](http://zsh.sourceforge.net/)
+- [Zsh](https://zsh.sourceforge.net/)
 
 ## Installation
 

--- a/contributing/getting-involved/en.md
+++ b/contributing/getting-involved/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Getting Involved"
-lastmod = "2017-07-22T15:24:32+03:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # Getting Involved
 
@@ -35,7 +35,7 @@ Alongside the forums, you can communicate with developers or others in the commu
 - [Facebook](https://www.facebook.com/get.solus)
 - [Google+ Page](https://plus.google.com/u/0/+Solus-Project)
 - [Google+ Community](https://plus.google.com/communities/104830131595272878110)
-- [Reddit](http://www.reddit.com/r/SolusProject/) 
+- [Reddit](https://www.reddit.com/r/SolusProject/) 
 - [Twitter](https://twitter.com/solusproject)
 
 ## Improving Documentation

--- a/hardware/ios-support/en.md
+++ b/hardware/ios-support/en.md
@@ -1,10 +1,10 @@
 +++
 title = "iOS Support"
-lastmod = "2017-05-16T16:50:16+03:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # iOS Support
 
-Historically, iOS support on Linux has been quirky and typically done via partial implementations, such as [libimobiledevice](http://www.libimobiledevice.org/) and [libgpod](http://www.gtkpod.org/libgpod/). As software that Solus provides 
+Historically, iOS support on Linux has been quirky and typically done via partial implementations, such as [libimobiledevice](https://www.libimobiledevice.org/) and [libgpod](http://www.gtkpod.org/libgpod/). As software that Solus provides 
 leverages these implementations, it is likely that if you have an Apple device running an iOS version newer than 4.3.x, you will not be able to utilize it for the synchronizing of content such as music and video.
 
 ## Checking Compatibility 

--- a/package-management/repo-management/en.md
+++ b/package-management/repo-management/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Repository Management"
-lastmod = "2017-07-22T15:15:45+03:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # Repository Management
 
@@ -17,7 +17,7 @@ sudo eopkg add-repo Name Url
 For example:
 
 ``` bash
-sudo eopkg add-repo Example http://example.com/repo/eopkg-index.xml.gz
+sudo eopkg add-repo Example https://example.com/repo/eopkg-index.xml.gz
 ```
 
 **Note:** This does not enable the repository.

--- a/packaging/package.yml/en.md
+++ b/packaging/package.yml/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Package.yml"
-lastmod = "2018-07-03T12:32:00+02:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # Package.yml
 
@@ -55,7 +55,7 @@ Key Name | Type | Description
 **name** | `string` | The name of the package. This is also used as the base of all sub-package names. Unless unavoidable, this should match the upstream name
 **version** | `string` | The version of the currently packaged software. This is taken from the tarball in most cases.
 **release** | `integer` | Specifies the current release number. Updates in the package number are based on this `release` number, *not* the `version` number. As such, to release an update to users, this number must be incremented by one.
-**license** | `string(s)` | Valid upstream license(s). Try to ensure these use [SPDX identifiers](http://spdx.org/licenses/).
+**license** | `string(s)` | Valid upstream license(s). Try to ensure these use [SPDX identifiers](https://spdx.org/licenses/).
 **source** | `dict(s)` | Upstream source location (i.e. tarball), with the valid `sha256sum` as a value
 **component** | `string` | Component / group of packages this package belongs to. Check available components via `eopkg lc`
 **summary** | `string` | Brief package summary, or display name

--- a/software/java/en.md
+++ b/software/java/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Java"
-lastmod = "2018-01-04T06:24:56+03:00"
+lastmod = "2018-07-19T08:40:00+01:00"
 +++
 # Java
 
@@ -14,7 +14,7 @@ You can set up Java by following the instructions below:
 
 ## JRE
 
-Grab the Java Runtime Environment (JRE) as `.tar.gz` from the [Oracle Download Page](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html).
+Grab the Java Runtime Environment (JRE) as `.tar.gz` from the [Oracle Download Page](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html).
 
 Extract JRE and move it to /opt:
 


### PR DESCRIPTION
# Description

Now all links that have support for using https certificates use https. There is currently just one link left where the site doesn't support https and that one is http://www.gtkpod.org in ios-support...
