### PR TITLE
software: Update java instructions to 8u181

### DIFF
--- a/software/java/en.md
+++ b/software/java/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Java"
-lastmod = "2018-07-19T08:40:00+01:00"
+lastmod = "2018-08-05T04:15:00+01:00"
 +++
 # Java
 
@@ -20,34 +20,36 @@ Extract JRE and move it to /opt:
 
 ``` bash
 cd ~/Downloads
-tar xf jre-8u152-linux-x64.tar.gz
-sudo mv jre1.8.0_152 /opt/
-sudo ln -svf /opt/jre1.8.0_152/bin/java /usr/bin/java
+tar xf jre-8u181-linux-x64.tar.gz
+sudo mkdir -p /opt
+sudo mv jre1.8.0_181 /opt/
+sudo ln -svf /opt/jre1.8.0_181/bin/java /usr/bin/java
 ```
 
 To enable Java in Firefox:
 
 ``` bash
 mkdir -p ~/.mozilla/plugins
-ln -s /opt/jre1.8.0_152/lib/amd64/libnpjp2.so ~/.mozilla/plugins/libnpjp2.so
+ln -s /opt/jre1.8.0_181/lib/amd64/libnpjp2.so ~/.mozilla/plugins/libnpjp2.so
 ```
 
 ## JDK
 
-Grab the Java Development Kit (JDK) as `.tar.gz` from the [Oracle Download Page](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133152.html).
+Grab the Java Development Kit (JDK) as `.tar.gz` from the [Oracle Download Page](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 Extract JDK and move it to /opt:
 
 ``` bash
 cd ~/Downloads
-tar xf jdk-8u152-linux-x64.tar.gz
-sudo mv jdk1.8.0_152 /opt/
-sudo ln -svf /opt/jdk1.8.0_152/bin/java /usr/bin/java
+tar xf jdk-8u181-linux-x64.tar.gz
+sudo mkdir -p /opt
+sudo mv jdk1.8.0_181 /opt/
+sudo ln -svf /opt/jdk1.8.0_181/bin/java /usr/bin/java
 ```
 
 To enable Java in Firefox:
 
 ``` bash
 mkdir -p ~/.mozilla/plugins
-ln -s /opt/jdk1.8.0_152/jre/lib/amd64/libnpjp2.so ~/.mozilla/plugins/libnpjp2.so
+ln -s /opt/jdk1.8.0_181/jre/lib/amd64/libnpjp2.so ~/.mozilla/plugins/libnpjp2.so
 ```


### PR DESCRIPTION
This is said to be the final public release to java8.

- Fix jdk url
- Don't assume /opt exists (it didn't for me)

Signed-off-by: Peter O'Connor <peter@solus-project.com>