### PR TITLE
Updates the PR-template and moves it in to .github folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Description
+
+<Info on what this pull request adds>
+
+### Submitter Checklist
+
+- [ ] Updated the "lastmod" portion at the top of any modified Markdown files.
+- [ ] Squashed commits with `git rebase -i` (if needed)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-# Description
-
-<Info on what this pull request adds>
-
-[//]: # (Reminder: Always update the "lastmod" portion at the top of any modified Markdown files)


### PR DESCRIPTION
## Description

This is what the new PR-template will look like. Mostly the same but with a checklist and added information about squashing commits. I also moved the template to a new .github folder to reduce clutter and make it simpler in the future if `CONTRIBUTING.md` or `ISSUE_TEMPLATE.md` gets added.

### Submitter Checklist

- [ ] Updated the "lastmod" portion at the top of any modified Markdown files.
- [ ] Squashed commits with `git rebase -i` (if needed)
