### PR TITLE
Budgie: Add info on how to close terminal after panel replace

### DIFF
--- a/budgie/restoring-panel-defaults/en.md
+++ b/budgie/restoring-panel-defaults/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Restoring Panel Defaults"
-lastmod = "2017-11-08T21:15:00+01:00"
+lastmod = "2018-09-30T18:09:57+02:00"
 +++
 # Restoring Panel Defaults
 
@@ -9,3 +9,4 @@ To restore Budgie's default panel settings, run the command below
 ``` bash
 budgie-panel --reset --replace &
 ```
+After this you can press CTRL + D to close the terminal without closing the Budgie Panel process.


### PR DESCRIPTION


## Description

Add info on how to close the terminal after a panel reset and replace. To avoid confused users like this one: https://plus.google.com/u/0/110844398985565987263/posts/SRARvTQevAu

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
